### PR TITLE
Permission denied for clone URI

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -58,7 +58,7 @@ For API Guidelines, click [here](http://developer.spotify.com/download/spotify-a
  1. Sign up for a [developer account on Spotify](http://developer.spotify.com/en/spotify-apps-api/developer-signup/) 
  2. Open Terminal, `mkdir ~/Spotify`
  3. `cd ~/Spotify`
- 4. `git clone git@github.com:spotify/apps-tutorial.git`
+ 4. `git clone git://github.com/spotify/apps-tutorial.git`
  6. Download the [latest version of Spotify](http://spotify.com/download)
  7. Open Spotify and type "spotify:app:tutorial" in the search bar
 


### PR DESCRIPTION
The clone URI (git@github.com:spotify/apps-tutorial.git) in README.mkd seems to be invalid. Have replaced it with a valid read-only URI (git://github.com/spotify/apps-tutorial.git)
