### PR TITLE
Update app path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a Spotify App that explains shows useful code snippets that can help you
  3. `cd ~/Spotify`
  4. `git clone git://github.com/spotify/apps-tutorial.git`
  6. Download the [latest version of Spotify](http://spotify.com/download)
- 7. Open Spotify and type "spotify:app:tutorial" in the search bar (restart Spotify completely in case it doesn't find the App at first)
+ 7. Open Spotify and type "spotify:app:api-tutorial" in the search bar (restart Spotify completely in case it doesn't find the App at first)
 
 ## More information
 

--- a/index.html
+++ b/index.html
@@ -17,47 +17,47 @@
                 <img src="/img/spotify-char.png" class="right" />
                 <h4>Getting started</h4>
                 <ul>
-                    <li><a href="spotify:app:tutorial:getting-started:manifest">Creating your manifest file</a></li>
-                    <li><a href="spotify:app:tutorial:getting-started:arguments">Handling arguments and creating navigational tabs</a></li>
-                    <li><a href="spotify:app:tutorial:getting-started:drag-drop">Dragging and dropping content into an app</a></li>
-                    <li><a href="spotify:app:tutorial:getting-started:share">Show "Share" popup</a></li>
+                    <li><a href="spotify:app:api-tutorial:getting-started:manifest">Creating your manifest file</a></li>
+                    <li><a href="spotify:app:api-tutorial:getting-started:arguments">Handling arguments and creating navigational tabs</a></li>
+                    <li><a href="spotify:app:api-tutorial:getting-started:drag-drop">Dragging and dropping content into an app</a></li>
+                    <li><a href="spotify:app:api-tutorial:getting-started:share">Show "Share" popup</a></li>
                 </ul>
 
                 <h4>UI</h4>
                 <ul>
-                    <li><a href="spotify:app:tutorial:ui:buttons">Using standard components for buttons</a></li>
-                    <li><a href="spotify:app:tutorial:ui:list-view">Showing a list of tracks</a></li>
+                    <li><a href="spotify:app:api-tutorial:ui:buttons">Using standard components for buttons</a></li>
+                    <li><a href="spotify:app:api-tutorial:ui:list-view">Showing a list of tracks</a></li>
                 </ul>
 
                 <h4>Playing music</h4>
                 <ul>
-                    <li><a href="spotify:app:tutorial:playing:play-track">Play a single track</a></li>
-                    <li><a href="spotify:app:tutorial:playing:play-list-tracks">Play a list of tracks</a></li>
-                    <li><a href="spotify:app:tutorial:playing:current-track">Get the currently playing track</a></li>
-                    <li><a href="spotify:app:tutorial:playing:click-to-play">Create a play/pause button with an HTML element</a></li>
-                    <li><a href="spotify:app:tutorial:playing:skip-track">Skip to the next or previous track</a></li>
-                    <li><a href="spotify:app:tutorial:playing:star-track">Star and unstar a track</a></li>
-                    <li><a href="spotify:app:tutorial:playing:user-toplist">Get a user's top tracks</a></li>
+                    <li><a href="spotify:app:api-tutorial:playing:play-track">Play a single track</a></li>
+                    <li><a href="spotify:app:api-tutorial:playing:play-list-tracks">Play a list of tracks</a></li>
+                    <li><a href="spotify:app:api-tutorial:playing:current-track">Get the currently playing track</a></li>
+                    <li><a href="spotify:app:api-tutorial:playing:click-to-play">Create a play/pause button with an HTML element</a></li>
+                    <li><a href="spotify:app:api-tutorial:playing:skip-track">Skip to the next or previous track</a></li>
+                    <li><a href="spotify:app:api-tutorial:playing:star-track">Star and unstar a track</a></li>
+                    <li><a href="spotify:app:api-tutorial:playing:user-toplist">Get a user's top tracks</a></li>
                 </ul>
 
                 <h4>Searching</h4>
                 <ul>
-                    <li><a href="spotify:app:tutorial:search:search">Returning all tracks with a given search query</a></li>
-                    <li><a href="spotify:app:tutorial:search:search-albums-artist">Search albums for an artist</a></li>
+                    <li><a href="spotify:app:api-tutorial:search:search">Returning all tracks with a given search query</a></li>
+                    <li><a href="spotify:app:api-tutorial:search:search-albums-artist">Search albums for an artist</a></li>
                 </ul>
 
                 <h4>Playlists</h4>
                 <ul>
-                    <li><a href="spotify:app:tutorial:playlist:add-track-playlist">Add a track to a playlist</a></li>
-                    <li><a href="spotify:app:tutorial:playlist:get-tracks-from-playlist">Get tracks from a playlist URL</a></li>
-                    <li><a href="spotify:app:tutorial:playlist:subscribe">Subscribe and unsubscribe from a playlist</a></li>
-                    <li><a href="spotify:app:tutorial:playlist:playlist-mosaic">Showing a playlist mosaic image</a></li>
+                    <li><a href="spotify:app:api-tutorial:playlist:add-track-playlist">Add a track to a playlist</a></li>
+                    <li><a href="spotify:app:api-tutorial:playlist:get-tracks-from-playlist">Get tracks from a playlist URL</a></li>
+                    <li><a href="spotify:app:api-tutorial:playlist:subscribe">Subscribe and unsubscribe from a playlist</a></li>
+                    <li><a href="spotify:app:api-tutorial:playlist:playlist-mosaic">Showing a playlist mosaic image</a></li>
                 </ul>
 
                 <h4>Interacting with Facebook</h4>
                 <ul>
-                    <li><a href="spotify:app:tutorial:facebook:facebook-auth">Authenticate a user with Facebook</a></li>
-                    <li><a href="spotify:app:tutorial:facebook:facebook-listening-history">Get a user's listening history from Facebook</a></li>
+                    <li><a href="spotify:app:api-tutorial:facebook:facebook-auth">Authenticate a user with Facebook</a></li>
+                    <li><a href="spotify:app:api-tutorial:facebook:facebook-listening-history">Get a user's listening history from Facebook</a></li>
                 </ul>
 
                 <h4>Experimental &amp; Unsupported</h4>

--- a/js/tutorial.js
+++ b/js/tutorial.js
@@ -29,7 +29,7 @@ window.onload = function() {
             if (xhr.readyState != 4 || xhr.status != 200) return;
 
             var wrapper = document.getElementById('wrapper');
-            wrapper.innerHTML = args[0] === 'index' ? '' : '<ul class="breadcrumb"><li><a href="spotify:app:tutorial:index">&laquo; Back to main page</a></li></ul>';
+            wrapper.innerHTML = args[0] === 'index' ? '' : '<ul class="breadcrumb"><li><a href="spotify:app:api-tutorial:index">&laquo; Back to main page</a></li></ul>';
             wrapper.innerHTML += xhr.responseText;
 
             window.scrollTo(0, 0);

--- a/tabs.html
+++ b/tabs.html
@@ -15,7 +15,7 @@
         <div class="section">
             <h1>Secondary tab</h1>
             <p class="description">This is the content for the second tab. If you want to see how the tab change has been handled, read
-            <a href="spotify:app:tutorial:getting-started:arguments">Handling arguments and creating navigational tabs</a>.
+            <a href="spotify:app:api-tutorial:getting-started:arguments">Handling arguments and creating navigational tabs</a>.
             </p>
         </div>
     </div>

--- a/tutorials/getting-started/arguments.html
+++ b/tutorials/getting-started/arguments.html
@@ -63,7 +63,7 @@
     <p class="description">For a small app, showing and hiding certain elements on a page can be enough. However, a different approach would be to split the content in several HTML pages.</p>
     <p class="description">Links should look like this:</p>
     <div class="code-block">
-    <pre><code data-language="html">&lt;a href="spotify:app:tutorial:mypage"&gt;A link to a page&lt;/a&gt;</code></pre>
+    <pre><code data-language="html">&lt;a href="spotify:app:api-tutorial:mypage"&gt;A link to a page&lt;/a&gt;</code></pre>
     </div>
     <p class="description">You can still navigate to an internal page using a link such as this:</p>
     <div class="code-block">
@@ -71,7 +71,7 @@
     </div>
     <p class="description">However, Spotify URIs are cleaner, don't expose implementation and work across Spotify, not only inside a given app. In addition, they manage tab highlighting. For instance, a link like this:
     <div class="code-block">
-    <pre><code data-language="html">&lt;a href="spotify:app:tutorial:tabs:section"&gt;A link to a section in the 'Tabs' tab&lt;/a&gt;</code></pre>
+    <pre><code data-language="html">&lt;a href="spotify:app:api-tutorial:tabs:section"&gt;A link to a section in the 'Tabs' tab&lt;/a&gt;</code></pre>
     </div>
     <p class="description">Will highlight our second tab (the one with label 'How to use tabs') because the 'tabs' part in the URI matches the arguments set for that tab in the manifest.json file.</p>
 </div>


### PR DESCRIPTION
Updates the README and link references to app path to match manifest BundleIdentifier.

before: **spotify:app:tutorial**

after: **spotify:app:api-tutorial**

closes spotify/apps-tutorial#6
